### PR TITLE
to pick up meck 0.8.2

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -11,7 +11,7 @@
 {deps, [
         {lager, ".*", {git, "git://github.com/basho/lager", {tag, "2.0.3"}}},
         {getopt, ".*", {git, "git://github.com/jcomellas/getopt", {tag, "v0.4"}}},
-        {meck, "0.8.1", {git, "git://github.com/basho/meck.git", {tag, "0.8.1"}}},
+        {meck, "0.8.2", {git, "git://github.com/basho/meck.git", {tag, "0.8.2"}}},
         {mapred_verify, ".*", {git, "git://github.com/basho/mapred_verify", {branch, "master"}}},
         {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client", {branch, "master"}}},
         {riakhttpc, ".*", {git, "git://github.com/basho/riak-erlang-http-client", {branch, "master"}}},


### PR DESCRIPTION
The version mismatch  cause following  error

==> druuid (get-deps)
==> workspace (get-deps)
ERROR: Dependency dir /var/lib/jenkins/jobs/riak_test/workspace/deps/meck failed application validation with reason:
{version_mismatch,{"/var/lib/jenkins/jobs/riak_test/workspace/deps/meck/src/meck.app.src",
                   {expected,"0.8.1"},
                   {has,"0.8.2"}}}.
ERROR: 'get-deps' failed while processing /var/lib/jenkins/jobs/riak_test/workspace: rebar_abort
make: **\* [deps] Error 1
